### PR TITLE
DX improvements for tailscale on Render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -qq update \
 RUN useradd --no-log-init --create-home --user-group --uid 1000 render
 
 USER 1000:1000
-COPY --chown=1000:1000 *.sh /home/render/
+COPY --chown=1000:1000 run-tailscale.sh start.sh /home/render/
 
 # install Tailscale as root
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -qq update \
     ca-certificates \
     netcat \
     wget \
+    dnsutils \
   > /dev/null \
   && apt-get -qq clean \
   && rm -rf \
@@ -17,6 +18,7 @@ RUN apt-get -qq update \
 RUN useradd --no-log-init --create-home --user-group --uid 1000 render
 
 USER 1000:1000
+RUN echo "+search +short" > /home/render/.digrc
 COPY --chown=1000:1000 run-tailscale.sh start.sh /home/render/
 
 # install Tailscale as root

--- a/install-tailscale.sh
+++ b/install-tailscale.sh
@@ -3,6 +3,6 @@ set -x
 TAILSCALE_VERSION=${TAILSCALE_VERSION:-1.14.0}
 TS_FILE=tailscale_${TAILSCALE_VERSION}_amd64.tgz
 wget -q "https://pkgs.tailscale.com/stable/${TS_FILE}" && tar xzf "${TS_FILE}" --strip-components=1
-cp -r tailscale tailscaled /home/render/
+cp -r tailscale tailscaled /usr/bin/
 
 mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,16 @@
+services:
+  - type: pserv
+    name: render-subnet-router
+    env: docker
+    envVars:
+      - key: TAILSCALE_AUTHKEY
+        sync: false
+      - key: TAILSCALE_VERSION
+        value: 1.14.0
+      - key: ADVERTISE_ROUTES
+        value: 10.0.0.0/8
+    disk:
+      name: tailscale-state
+      mountPath: /var/lib/tailscale
+      sizeGB: 1
+

--- a/run-tailscale.sh
+++ b/run-tailscale.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 if [[ ${TAILSCALE_AUTHKEY:-} ]]; then
-  /home/render/tailscaled -tun=userspace-networking -socks5-server=localhost:1055 &
+  tailscaled -tun=userspace-networking -socks5-server=localhost:1055 &
 
   ADVERTISE_ROUTES=${ADVERTISE_ROUTES:-10.0.0.0/8}
-  until /home/render/tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES"; do
+  until tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES"; do
     sleep 0.1
   done
   export ALL_PROXY=socks5://localhost:1055/
-  tailscale_ip=$(/home/render/tailscale ip)
+  tailscale_ip=$(tailscale ip)
   echo "Tailscale is up at IP ${tailscale_ip}"
 fi

--- a/run-tailscale.sh
+++ b/run-tailscale.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 if [[ ${TAILSCALE_AUTHKEY:-} ]]; then
-  /home/render/tailscaled -socket=/home/render/tailscaled.sock \
-    -state=/home/render/tailscaled.state \
-    -tun=userspace-networking \
-    -socks5-server=localhost:1055 &
+  /home/render/tailscaled -tun=userspace-networking -socks5-server=localhost:1055 &
 
   ADVERTISE_ROUTES=${ADVERTISE_ROUTES:-10.0.0.0/8}
-  until /home/render/tailscale --socket=/home/render/tailscaled.sock up --authkey="${TAILSCALE_AUTHKEY}" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES"; do
+  until /home/render/tailscale up --authkey="${TAILSCALE_AUTHKEY}" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES"; do
     sleep 0.1
   done
   export ALL_PROXY=socks5://localhost:1055/
-  tailscale_ip=$(/home/render/tailscale --socket=/home/render/tailscaled.sock ip)
+  tailscale_ip=$(/home/render/tailscale ip)
   echo "Tailscale is up at IP ${tailscale_ip}"
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Ignore Tailscale during port detection on Render
 if [[ ${RENDER_PORT_DETECTOR:-} != "true" ]]; then
-  # shellcheck source=projectmgr/run-tailscale.sh
   . /home/render/run-tailscale.sh
 fi
 


### PR DESCRIPTION
- Adds a render.yaml file with a disk at `/var/lib/tailscale` to store tailscale state across deploys. This makes the tailscale "machine" persistent and allows for the use of one-time tailscale keys. As part of this I moved the socket and state files back to their default locations (`/var/run/tailscale` and `/var/lib/tailscale`, respectively).
- Adds `dnsutils` and a `.digrc` file so you can easily `dig` a Render service name to get the internal IP at which the service is available in the subnet
- Moves `tailscale` and `tailscaled` to `/usr/bin`